### PR TITLE
Make HOME_BREW location configurable in Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ QMTECH_CABLE ?= tigard
 
 # This workaround is only required for macOS, because Apple has explicitly disabled OpenMP support in their compilers.
 ifeq ($(shell uname -s),Darwin)
-NEXTPNR_BUILD_ENV = env CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
+HOME_BREW = $(shell brew --prefix llvm)
+NEXTPNR_BUILD_ENV = env CC=${HOME_BREW}/bin/clang CXX=${HOME_BREW}/bin/clang++ LDFLAGS="-L${HOME_BREW}/lib -Wl,-rpath,${HOME_BREW}/lib"
 NEXTPNR_CMAKE_FLAGS = -DBUILD_GUI=0
 endif
 


### PR DESCRIPTION
The location of the clang compiler in home-brew seems to vary between Darwin versions. This patch pins it down so that it can be determined automatically. I use the command:

brew --prefix llvm        

which on my machine evaluates to:

/opt/homebrew/opt/llvm
